### PR TITLE
(feat): add the /shutdown route; (feat): add daemon mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,6 +687,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "fork"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c5b9b0bce249a456f83ac4404e8baad0d2ba81cf651949719a4f74eb7323bb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,6 +2536,7 @@ name = "tts-proxy"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "fork",
  "reqwest",
  "serde",
  "tokio",

--- a/tts-proxy/Cargo.toml
+++ b/tts-proxy/Cargo.toml
@@ -22,3 +22,6 @@ tracing = "0.1.26"
 tracing-appender = "0.1.2"
 tracing-subscriber = "0.2.19"
 
+[target.'cfg(unix)'.dependencies]
+fork = "0.1.18"
+

--- a/tts-proxy/src/config.rs
+++ b/tts-proxy/src/config.rs
@@ -21,6 +21,9 @@ pub struct Config {
     /// The path to the directory to store the logs in.
     #[clap(short, long, name = "PATH")]
     pub log_directory: Option<String>,
+    /// Start the proxy as a daemon.
+    #[clap(short, long)]
+    pub daemonize: bool,
 }
 
 impl Default for Config {
@@ -31,6 +34,7 @@ impl Default for Config {
             retry_attempts: NonZeroU8::new(3).unwrap(),
             api_timeout_seconds: 180,
             log_directory: None,
+            daemonize: false,
         }
     }
 }

--- a/tts-proxy/src/main.rs
+++ b/tts-proxy/src/main.rs
@@ -4,7 +4,8 @@ use tts_proxy::start;
 fn main() -> std::io::Result<()> {
     let config = tts_proxy::config::Config::parse();
 
-    if cfg!(target_family = "unix") && config.daemonize {
+    #[cfg(target_family = "unix")]
+    if config.daemonize {
         match fork::daemon(false, true) {
             Ok(fork::Fork::Child) => (), // We're in the granchild process, do nothing
             Ok(_) => {

--- a/tts-proxy/src/main.rs
+++ b/tts-proxy/src/main.rs
@@ -1,10 +1,30 @@
 use clap::Clap;
 use tts_proxy::start;
 
-#[tokio::main]
-async fn main() -> std::io::Result<()> {
-    let mut config = tts_proxy::config::Config::parse();
+fn main() -> std::io::Result<()> {
+    let config = tts_proxy::config::Config::parse();
 
+    if cfg!(target_family = "unix") && config.daemonize {
+        match fork::daemon(false, true) {
+            Ok(fork::Fork::Child) => (), // We're in the granchild process, do nothing
+            Ok(_) => {
+                // We're in the intermediate child process, exit
+                std::process::exit(0);
+            }
+            Err(_) => {
+                panic!("Failed to daemonize the process.");
+            }
+        }
+    }
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async move { actual_main(config).await })
+}
+
+async fn actual_main(mut config: tts_proxy::config::Config) -> std::io::Result<()> {
     if let Some(directory) = config.log_directory.take() {
         let file_appender = tracing_appender::rolling::never(directory, "tts-proxy.log");
         let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
@@ -18,7 +38,6 @@ async fn main() -> std::io::Result<()> {
         let filter = std::env::var("RUST_LOG").unwrap_or_else(|_| "none".to_owned());
         tracing_subscriber::fmt().with_env_filter(filter).init();
     }
-
     start(config).await;
     Ok(())
 }


### PR DESCRIPTION
* Add an endpoint for shutting down the proxy
* Add an option to launch the proxy as a daemon on unix. 
    - This is needed because on most unix systems, a child process will be automatically killed upon the exit of its parent process. To bypass this behavior, the child process may be forked, terminating the parent process, and continuing as a brand new process with its own session.
    - AFAICT, windows doesn't exhibit this behavior, so the proxy should run in the background automatically (though further testing is required)